### PR TITLE
Add Discord Webhook Channel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+build
+composer.phar
+composer.lock

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,21 @@
+filter:
+    excluded_paths: [tests/*]
+
+checks:
+    php:
+        remove_extra_empty_lines: true
+        remove_php_closing_tag: true
+        remove_trailing_whitespace: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: true
+            order_alphabetically: true
+        fix_php_opening_tag: true
+        fix_linefeed: true
+        fix_line_ending: true
+        fix_identation_4spaces: true
+        fix_doc_comments: true
+
+tools:
+    external_code_coverage: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+preset: laravel
+
+linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest"
+    - COMPOSER_FLAGS=""
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+
+script:
+  - phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to `discord-webhook` will be documented in this file
+
+## 1.0.0 - 2016-10-26
+
+- Initial Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) Dr. Dr. Jojo <drdrjojo2k@gmail.com>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,161 @@
-# new-channels
+# Discord Webhook Notifications Channel for Laravel 5.3 
 
-Discuss about new channel proposals our share your finished channels in the [proposal issue](https://github.com/laravel-notification-channels/new-channels/issues/6).
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/discord-webhook.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/discord-webhook)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/laravel-notification-channels/discord-webhook/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/discord-webhook)
+[![StyleCI](https://styleci.io/repos/:style_ci_id/shield)](https://styleci.io/repos/:style_ci_id)
+[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
+[![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/discord-webhook.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/discord-webhook)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/discord-webhook/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/discord-webhook/?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/discord-webhook.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/discord-webhook)
+[![Discord](https://discordapp.com/api/guilds/240540496068476928/widget.png)](https://discord.gg/9RP6RPg)
 
-Take a look at our [FAQ](http://laravel-notification-channels.com/) to see our small list of rules, to provide top-notch notification channels.
+This package makes it easy to send notifications using [Discord Webhook](https://support.discordapp.com/hc/en-us/articles/228383668-Using-Webhooks) with Laravel 5.3.
+
+## Contents
+
+- [Installation](#installation)
+	- [Setting up the Discord Webhook service](#setting-up-your-discord-webhook)
+- [Usage](#usage)
+    - [Routing a message](#routing-a-message)
+    - [Send a message with embeds](#send-a-message-with-embeds)
+    - [Send a message with file upload](#send-a-message-with-file-upload)
+	- [Available Message methods](#available-message-methods)
+	- [Available Embed methods](#available-embed-methods)
+- [Changelog](#changelog)
+- [Testing](#testing)
+- [Security](#security)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [License](#license)
+
+
+## Installation
+
+You can install the package via composer:
+
+``` bash
+composer require laravel-notification-channels/discord-webhook
+```
+
+### Setting up your Discord Webhook
+
+Follow the official guide [Using Webhook](https://support.discordapp.com/hc/en-us/articles/228383668-Using-Webhooks) to set up your Discord Webhook.
+
+## Usage
+
+Now you can use the channel in your `via()` method inside the notification:
+
+``` php
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\DiscordWebhookChannel;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class Application extends Notification
+{
+    public function via($notifiable)
+    {
+        return [DiscordWebhookChannel::class];
+    }
+
+    public function toDiscordWebhook($notifiable)
+    {
+        return (new DiscordWebhookMessage())
+            ->content('Your guild received a new membership application!');
+    }
+}
+```
+
+### Routing a message
+
+In order to let your Notification know which Webhook (Discord Channel) you are targeting, add the `routeNotificationForDiscordWebhook` method to your Notifiable model:
+
+``` php
+public function routeNotificationForDiscordWebhook()
+{
+    return 'https://discordapp.com/api/webhooks/{webhook.id}/{webhook.token}';
+}
+```
+
+Add `?wait=true` to your Webhook URL, to receive the sent message:
+
+``` php
+return 'https://discordapp.com/api/webhooks/{webhook.id}/{webhook.token}?wait=true';
+```
+
+### Send a message with embeds
+
+Discord Webhook allows you to add embedded rich content to your message:
+
+``` php
+public function toDiscordWebhook($notifiable)
+{
+    return (new DiscordWebhookMessage())
+        ->from('Raid Calendar')
+        ->content('**Next Raids**')
+        ->embed(function ($embed) {
+            $embed->title('Dragon Dungeon')->description('*on Monday*')
+                ->field('Raid Leader', 'TheTank', true)
+                ->field('Co-Leader', 'HealMePls', true);
+        });
+}
+```
+
+### Send a message with file upload
+
+Discord Webhook allows you to upload a file with your message:
+
+``` php
+public function toDiscordWebhook($notifiable)
+{
+    return (new DiscordWebhookMessage())
+        ->content('__Member of the Day:__')
+        ->file(\Storage::get('motd_avatar.png'), 'member_of_the_day.png');
+}
+```
+
+### Available Message methods
+
+- `content($text)`: The message contents (up to 2000 characters).
+- `from($username[, $avatar_url])`: Override the default username and avatar (optional) of the webhook.
+- ~~- `tts()`: Send as a TTS message.~~ (Does currently not work for Webhooks)
+- `file($content, $filename)`: The contents of the file being sent. **NOTE:** Does not work with embedded rich content
+- `embed($callback)`: Define (up to 10) embedded rich content for the message. (see [Example](#send-a-message-with-embeds) and [Embeds](#available-embed-methods))
+
+### Available Embed methods
+
+- `title($title[, $url])`: Set the title of embed.
+- `description($text)`: Set the description of embed.
+- `color($color_int)`: Set the color code of the embed.
+- `footer($text[, $icon_url])`: Set the footer information.
+- `image($img_url)`: Set the image information.
+- `thumbnail($img_url)`: Set the thumbnail information.
+- `author($name[, $url, $icon_url])`: Set the author information.
+- `field($name, $value[, $inline_bool])`: Set the (inline) fields information.
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+
+## Testing
+
+``` bash
+$ composer test
+```
+
+## Security
+
+If you discover any security related issues, please email drdrjojo2k@gmail.com instead of using the issue tracker.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Credits
+
+- [Dr. Dr. Jojo](https://github.com/drdrjojo)
+- [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "laravel-notification-channels/discord-webhook",
+    "description": "Discord Webhook notifications channel for Laravel 5.3",
+    "homepage": "https://github.com/laravel-notification-channels/discord-webhook",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dr. Dr. Jojo",
+            "email": "drdrjojo2k@gmail.com",
+            "homepage": "https://github.com/drdrjojo",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.4",
+        "guzzlehttp/guzzle": "^6.2",
+        "illuminate/notifications": "^5.3",
+        "illuminate/support": "^5.1|^5.2|^5.3"
+    },
+    "require-dev": {
+        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "4.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\DiscordWebhook\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\DiscordWebhook\\Test\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="DiscordWebhook Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/DiscordWebhookChannel.php
+++ b/src/DiscordWebhookChannel.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook;
+
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException;
+use Psr\Http\Message\ResponseInterface;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\Exceptions\CouldNotSendNotification;
+use NotificationChannels\DiscordWebhook\Exceptions\InvalidMessage;
+
+class DiscordWebhookChannel
+{
+    /**
+     * The HTTP client instance.
+     *
+     * @var \GuzzleHttp\Client
+     */
+    protected $http;
+
+    /**
+     * The Content-Type for the HTTP Request.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Create a new Discord Webhook channel instance.
+     *
+     * @param \GuzzleHttp\Client $http
+     */
+    public function __construct(HttpClient $http)
+    {
+        $this->http = $http;
+        $this->type = 'json';
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     *
+     * @return mixed
+     *
+     * @throws \NotificationChannels\DiscordWebhook\Exceptions\CouldNotSendNotification
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        if (! $url = $notifiable->routeNotificationFor('discord-webhook')) {
+            return false;
+        }
+        $message = $notification->toDiscordWebhook($notifiable);
+
+        $payload = $this->buildPayload($message);
+
+        try {
+            $response = $this->http->post($url, [$this->type => $payload]);
+
+            return $this->getResponse($response);
+        } catch (ClientException $e) {
+            throw CouldNotSendNotification::serviceRespondedWithAnError($e);
+        } catch (\Exception $e) {
+            throw CouldNotSendNotification::couldNotCommunicateWithDiscordWebhook($e->getMessage());
+        }
+    }
+
+    /**
+     * Get the response for the sent notification.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return array
+     */
+    protected function getResponse(ResponseInterface $response)
+    {
+        $code = $response->getStatusCode();
+
+        if ($code == 200) {
+            return $this->getMessage($response->getBody()->getContents());
+        }
+
+        return [
+            'StatusCode' => $code,
+            'ReasonPhrase' => $response->getReasonPhrase(),
+        ];
+    }
+
+    /**
+     * Get the message that has been sent to Discord.
+     *
+     * @param string $content
+     *
+     * @return string|array
+     */
+    protected function getMessage($content)
+    {
+        $obj = json_decode($content);
+        if ($obj) {
+            $content = $obj;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Build up a payload for the Discord Webhook.
+     *
+     * @param \NotificationChannels\DiscordWebhook\DiscordWebhookMessage $message
+     *
+     * @return array
+     *
+     * @throws \NotificationChannels\DiscordWebhook\Exceptions\InvalidMessage
+     */
+    protected function buildPayload(DiscordWebhookMessage $message)
+    {
+        if ($this->checkMessageEmpty($message)) {
+            throw InvalidMessage::cannotSendAnEmptyMessage();
+        }
+
+        if (! is_null($message->file)) {
+            return $this->buildMultipartPayload($message);
+        }
+
+        return $this->buildJSONPayload($message);
+    }
+
+    /**
+     * Checks if the given Message is valid.
+     *
+     * @param \NotificationChannels\DiscordWebhook\DiscordWebhookMessage $message
+     *
+     * @return bool
+     */
+    protected function checkMessageEmpty($message)
+    {
+        if (is_null($message->content) && is_null($message->file) && is_null($message->embeds)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Build up a JSON payload for the Discord Webhook.
+     *
+     * @param \NotificationChannels\DiscordWebhook\DiscordWebhookMessage $message
+     *
+     * @return array
+     */
+    protected function buildJSONPayload(DiscordWebhookMessage $message)
+    {
+        $optionalFields = array_filter([
+            'username' => data_get($message, 'username'),
+            'avatar_url' => data_get($message, 'avatar_url'),
+            'tts' => data_get($message, 'tts'),
+            'timestamp' => data_get($message, 'timestamp'),
+        ]);
+
+        return array_merge([
+            'content' => $message->content,
+            'embeds' => $this->embeds($message),
+        ], $optionalFields);
+    }
+
+    /**
+     * Build up a Multipart payload for the Discord Webhook.
+     *
+     * @param \NotificationChannels\DiscordWebhook\DiscordWebhookMessage $message
+     *
+     * @return array
+     *
+     * @throws \NotificationChannels\DiscordWebhook\Exceptions\InvalidMessage
+     */
+    protected function buildMultipartPayload(DiscordWebhookMessage $message)
+    {
+        if (! is_null($message->embeds)) {
+            throw InvalidMessage::embedsNotSupportedWithFileUploads();
+        }
+
+        $this->type = 'multipart';
+
+        return collect($message)->forget('file')->reject(function ($value) {
+            return is_null($value);
+        })->map(function ($value, $key) {
+            return ['name' => $key, 'contents' => $value];
+        })->push($message->file)->values()->all();
+    }
+
+    /**
+     * Format the message's embedded content.
+     *
+     * @param \NotificationChannels\DiscordWebhook\DiscordWebhookMessage $message
+     *
+     * @return array
+     */
+    protected function embeds(DiscordWebhookMessage $message)
+    {
+        return collect($message->embeds)->map(function (DiscordWebhookEmbed $embed) {
+            return array_filter([
+                'color' => $embed->color,
+                'title' => $embed->title,
+                'description' => $embed->description,
+                'link' => $embed->url,
+                'thumbnail' => $embed->thumbnail,
+                'image' => $embed->image,
+                'footer' => $embed->footer,
+                'author' => $embed->author,
+                'fields' => $embed->fields,
+            ]);
+        })->all();
+    }
+}

--- a/src/DiscordWebhookEmbed.php
+++ b/src/DiscordWebhookEmbed.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook;
+
+class DiscordWebhookEmbed
+{
+    /**
+     * The title of embed.
+     *
+     * @var string
+     */
+    public $title;
+
+    /**
+     * The description of embed.
+     *
+     * @var string
+     */
+    public $description;
+
+    /**
+     * The URL of embed.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
+     * The color code of the embed.
+     *
+     * @var int
+     */
+    public $color;
+
+    /**
+     * The footer information.
+     *
+     * @var array
+     */
+    public $footer;
+
+    /**
+     * The image information.
+     *
+     * @var array
+     */
+    public $image;
+
+    /**
+     * The thumbnail information.
+     *
+     * @var array
+     */
+    public $thumbnail;
+
+    /**
+     * The author information.
+     *
+     * @var array
+     */
+    public $author;
+
+    /**
+     * The fields information.
+     *
+     * @var array
+     */
+    public $fields;
+
+    /**
+     * Set the title (url) of embed.
+     *
+     * @param string $title
+     * @param string|null $url
+     *
+     * @return $this
+     */
+    public function title($title, $url = '')
+    {
+        $this->title = $title;
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Set the description (text) of embed.
+     *
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function description($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Set the color code of the embed.
+     *
+     * @param int $code
+     *
+     * @return $this
+     */
+    public function color($code)
+    {
+        $this->color = $code;
+
+        return $this;
+    }
+
+    /**
+     * Set the footer information.
+     *
+     * @param string $text
+     * @param string|null $icon_url
+     *
+     * @return $this
+     */
+    public function footer($text, $icon_url = '')
+    {
+        $this->footer = [
+            'text' => $text,
+            'icon_url' => $icon_url,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Set the image (url) information.
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function image($url)
+    {
+        $this->image = [
+            'url' => $url,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Set the thumbnail (url) information.
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function thumbnail($url)
+    {
+        $this->thumbnail = [
+            'url' => $url,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Set the author information.
+     *
+     * @param string $name
+     * @param string|null $url
+     * @param string|null $icon_url
+     *
+     * @return $this
+     */
+    public function author($name, $url = '', $icon_url = '')
+    {
+        $this->author = [
+            'name' => $name,
+            'url' => $url,
+            'icon_url' => $icon_url,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Set the fields information.
+     *
+     * @param string $name
+     * @param string $value
+     * @param bool|null $inline
+     *
+     * @return $this
+     */
+    public function field($name, $value, $inline = false)
+    {
+        $this->fields[] = new DiscordWebhookEmbedField($name, $value, $inline);
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the embedded content.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'title' => $this->title,
+            'description' => $this->description,
+            'url' => $this->url,
+            'color' => $this->color,
+            'footer' => $this->footer,
+            'image' => $this->image,
+            'thumbnail' => $this->thumbnail,
+            'author' => $this->author,
+            'fields' => $this->fields,
+        ];
+    }
+}

--- a/src/DiscordWebhookEmbedField.php
+++ b/src/DiscordWebhookEmbedField.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook;
+
+class DiscordWebhookEmbedField
+{
+    /**
+     * The name of the field.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The value of the field.
+     *
+     * @var string
+     */
+    public $value;
+
+    /**
+     * Whether or not this field should display inline.
+     *
+     * @var bool
+     */
+    public $inline;
+
+    /**
+     * Create a new Embed Field instance.
+     *
+     * @param string $name
+     * @param string $value
+     * @param bool|null $inline
+     */
+    public function __construct($name, $value, $inline = false)
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->inline = $inline;
+    }
+
+    /**
+     * Set the name of the field.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the field.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function value($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the name of the field.
+     *
+     * @param bool|null $inline
+     *
+     * @return $this
+     */
+    public function inline($inline = true)
+    {
+        $this->inline = boolval($inline);
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the embedded field.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'value' => $this->value,
+            'inline' => $this->inline,
+        ];
+    }
+}

--- a/src/DiscordWebhookMessage.php
+++ b/src/DiscordWebhookMessage.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook;
+
+class DiscordWebhookMessage
+{
+    /**
+     * The message contents (up to 2000 characters).
+     *
+     * @var string
+     */
+    public $content;
+
+    /**
+     * Override the default username of the webhook.
+     *
+     * @var string|null
+     */
+    public $username;
+
+    /**
+     * Override the default avatar of the webhook.
+     *
+     * @var string|null
+     */
+    public $avatar_url;
+
+    /**
+     * true if this is a TTS message.
+     *
+     * @var string|null
+     */
+    public $tts = 'false';
+
+    /**
+     * The contents of the file being sent.
+     *
+     * @var array
+     */
+    public $file;
+
+    /**
+     * Embedded rich content.
+     *
+     * @var array
+     */
+    public $embeds;
+
+    /**
+     * Allows to set the content by creation.
+     *
+     * @param string $content
+     */
+    public function __construct($content = null)
+    {
+        if (! is_null($content)) {
+            $this->content($content);
+        }
+    }
+
+    /**
+     * Set the content of the message.
+     *
+     * @param string $content
+     *
+     * @return $this
+     */
+    public function content($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Override the default username and avatar url of the webhook.
+     *
+     * @param string $username
+     * @param string|null $avatar_url
+     *
+     * @return $this
+     */
+    public function from($username, $avatar_url = null)
+    {
+        $this->username = $username;
+
+        if (! is_null($avatar_url)) {
+            $this->avatar_url = $avatar_url;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Send as a TTS message.
+     *
+     * @param bool|null $enabled
+     *
+     * @return $this
+     */
+    public function tts($enabled = true)
+    {
+        $this->tts = $enabled ? 'true' : 'false';
+
+        return $this;
+    }
+
+    /**
+     * Set the contents and filename of the file being sent.
+     *
+     * @param string $contents
+     * @param string $filename
+     *
+     * @return $this
+     */
+    public function file($contents, $filename)
+    {
+        $this->file = [
+            'name' => 'file',
+            'contents' => $contents,
+            'filename' => $filename,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Define an embedded rich content for the message.
+     *
+     * @param \Closure $callback
+     *
+     * @return $this
+     */
+    public function embed(\Closure $callback)
+    {
+        $this->embeds[] = $embed = new DiscordWebhookEmbed;
+
+        $callback($embed);
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the message.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'content' => $this->content,
+            'username' => $this->username,
+            'avatar_url' => $this->avatar_url,
+            'tts' => $this->tts,
+            'file' => $this->file,
+            'embeds' => $this->embeds,
+        ];
+    }
+}

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Exceptions;
+
+use GuzzleHttp\Exception\ClientException;
+
+class CouldNotSendNotification extends \Exception
+{
+    /**
+     * Thrown when a 4xx http error code is received.
+     *
+     * @param \GuzzleHttp\Exception\ClientException $exception
+     *
+     * @return static
+     */
+    public static function serviceRespondedWithAnError(ClientException $exception)
+    {
+        $response = $exception->getResponse();
+        $code = $response->getStatusCode();
+        $message = $response->getBody()->getContents();
+
+        return new static("Discord Webhook responded with an error ({$code}): {$message}");
+    }
+
+    /**
+     * Thrown when the api is not reachable.
+     *
+     * @param string $message
+     *
+     * @return static
+     */
+    public static function couldNotCommunicateWithDiscordWebhook($message)
+    {
+        return new static("The communication with Discord Webhook failed. Reason: {$message}");
+    }
+}

--- a/src/Exceptions/InvalidMessage.php
+++ b/src/Exceptions/InvalidMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Exceptions;
+
+class InvalidMessage extends \Exception
+{
+    /**
+     * Thrown when a file upload contents an aembedded content.
+     * Because uploading files require a multipart/form-data request.
+     *
+     * @return static
+     */
+    public static function embedsNotSupportedWithFileUploads()
+    {
+        return new static('Embedded Content is not supported with File Uploads.');
+    }
+
+    /**
+     * Thrown when the message does not contain a content, file or message.
+     *
+     * @return static
+     */
+    public static function cannotSendAnEmptyMessage()
+    {
+        return new static('Cannot send an empty message');
+    }
+}

--- a/tests/DiscordWebhookChannelTest.php
+++ b/tests/DiscordWebhookChannelTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Mockery;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ClientException;
+use NotificationChannels\DiscordWebhook\DiscordWebhookChannel;
+use NotificationChannels\DiscordWebhook\Exceptions\InvalidMessage;
+use NotificationChannels\DiscordWebhook\Exceptions\CouldNotSendNotification;
+
+class DiscordWebhookChannelTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \GuzzleHttp\Client */
+    protected $httpClient;
+
+    /** @var \NotificationChannels\DiscordWebhook\DiscordWebhookChannel */
+    protected $channel;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->httpClient = Mockery::mock(new Client());
+        $this->channel = Mockery::mock(new DiscordWebhookChannel($this->httpClient));
+        $this->notifiable = new TestNotifiable();
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_ignore_other_route_notification()
+    {
+        $this->httpClient->shouldReceive('post')->never();
+        $this->channel->send(new TestOtherNotifiable(), new TestNotification());
+    }
+
+    /** @test */
+    public function it_can_send_a_notification()
+    {
+        $this->httpClient->shouldReceive('post')->once()->andReturn(new Response(204));
+        $this->channel->send($this->notifiable, new TestNotification());
+    }
+
+    /** @test */
+    public function it_can_send_notification_and_wait_for_response()
+    {
+        $this->httpClient->shouldReceive('post')->once()->andReturn(new Response(200, [], '{"json": true}'));
+        $this->channel->send($this->notifiable, new TestNotification());
+    }
+
+    /** @test */
+    public function it_can_send_a_file()
+    {
+        $this->httpClient->shouldReceive('post')->once()->andReturn(new Response(204));
+        $this->channel->send($this->notifiable, new TestFileNotification());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_it_could_not_send_a_notification()
+    {
+        $exception = new RequestException('Error', new Request('POST', 'webhook_fail'));
+        $this->httpClient->shouldReceive('post')->once()->andThrow($exception);
+        $this->setExpectedException(CouldNotSendNotification::class);
+        $this->channel->send($this->notifiable, new TestNotification());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_with_response_when_it_could_not_send_a_notification()
+    {
+        $exception = new ClientException('Error', new Request('POST', 'webhook_fail'), new Response(400));
+        $this->httpClient->shouldReceive('post')->once()->andThrow($exception);
+        $this->setExpectedException(CouldNotSendNotification::class);
+        $this->channel->send($this->notifiable, new TestNotification());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_message_is_empty()
+    {
+        $this->setExpectedException(InvalidMessage::class);
+        $this->channel->send($this->notifiable, new TestEmptyNotification());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_message_is_unsupported()
+    {
+        $this->setExpectedException(InvalidMessage::class);
+        $this->channel->send($this->notifiable, new TestUnsupportedNotification());
+    }
+}

--- a/tests/DiscordWebhookEmbedFieldTest.php
+++ b/tests/DiscordWebhookEmbedFieldTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use NotificationChannels\DiscordWebhook\DiscordWebhookEmbedField;
+
+class DiscordWebhookEmbedFieldTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \NotificationChannels\DiscordWebhook\DiscordWebhookEmbedField */
+    protected $embedField;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->embedField = new DiscordWebhookEmbedField('construct name', 'and value');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_construct_with_name_and_value()
+    {
+        $message = new DiscordWebhookEmbedField('my construct name', 'my construct value');
+        $this->assertEquals('my construct name', $message->name);
+        $this->assertEquals('my construct value', $message->value);
+    }
+
+    /** @test */
+    public function it_can_change_the_name()
+    {
+        $this->embedField->name('my name');
+        $this->assertEquals('my name', $this->embedField->name);
+    }
+
+    /** @test */
+    public function it_can_change_the_value()
+    {
+        $this->embedField->value('my value');
+        $this->assertEquals('my value', $this->embedField->value);
+    }
+
+    /** @test */
+    public function it_can_enable_inline()
+    {
+        $this->embedField->inline();
+        $this->assertTrue($this->embedField->inline);
+    }
+
+    /** @test */
+    public function it_can_disable_inline()
+    {
+        $this->embedField->inline(false);
+        $this->assertFalse($this->embedField->inline);
+    }
+}

--- a/tests/DiscordWebhookEmbedTest.php
+++ b/tests/DiscordWebhookEmbedTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Support\Arr;
+use NotificationChannels\DiscordWebhook\DiscordWebhookEmbed;
+
+class DiscordWebhookEmbedTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \NotificationChannels\DiscordWebhook\DiscordWebhookEmbed */
+    protected $embed;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->embed = new DiscordWebhookEmbed();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_set_the_title()
+    {
+        $this->embed->title('my title');
+        $this->assertEquals('my title', $this->embed->title);
+    }
+
+    /** @test */
+    public function it_can_set_the_title_and_url()
+    {
+        $this->embed->title('with url', 'title_url');
+        $this->assertEquals('with url', $this->embed->title);
+        $this->assertEquals('title_url', $this->embed->url);
+    }
+
+    /** @test */
+    public function it_can_set_the_description()
+    {
+        $this->embed->description('my description');
+        $this->assertEquals('my description', $this->embed->description);
+    }
+
+    /** @test */
+    public function it_can_set_the_color()
+    {
+        $this->embed->color(123);
+        $this->assertEquals(123, $this->embed->color);
+    }
+
+    /** @test */
+    public function it_can_set_the_footer_text()
+    {
+        $this->embed->footer('my footer');
+        $this->assertEquals('my footer', Arr::get($this->embed->footer, 'text'));
+    }
+
+    /** @test */
+    public function it_can_set_the_footer_text_and_icon_url()
+    {
+        $this->embed->footer('with icon', 'footer_icon');
+        $this->assertEquals('with icon', Arr::get($this->embed->footer, 'text'));
+        $this->assertEquals('footer_icon', Arr::get($this->embed->footer, 'icon_url'));
+    }
+
+    /** @test */
+    public function it_can_set_the_image_url()
+    {
+        $this->embed->image('image_url');
+        $this->assertEquals('image_url', Arr::get($this->embed->image, 'url'));
+    }
+
+    /** @test */
+    public function it_can_set_the_thumbnail_url()
+    {
+        $this->embed->thumbnail('thumb_url');
+        $this->assertEquals('thumb_url', Arr::get($this->embed->thumbnail, 'url'));
+    }
+
+    /** @test */
+    public function it_can_set_the_author_name()
+    {
+        $this->embed->author('me');
+        $this->assertEquals('me', Arr::get($this->embed->author, 'name'));
+    }
+
+    /** @test */
+    public function it_can_set_the_author_name_and_url()
+    {
+        $this->embed->author('with url', 'author_url');
+        $this->assertEquals('with url', Arr::get($this->embed->author, 'name'));
+        $this->assertEquals('author_url', Arr::get($this->embed->author, 'url'));
+    }
+
+    /** @test */
+    public function it_can_set_the_author_name_and_url_and_icon()
+    {
+        $this->embed->author('with icon', 'author_and_icon_url', 'for author');
+        $this->assertEquals('with icon', Arr::get($this->embed->author, 'name'));
+        $this->assertEquals('author_and_icon_url', Arr::get($this->embed->author, 'url'));
+        $this->assertEquals('for author', Arr::get($this->embed->author, 'icon_url'));
+    }
+
+    /** @test */
+    public function it_can_embed_field()
+    {
+        $this->embed->field('my name', 'my value');
+        $this->assertEquals('my name', Arr::get(Arr::first($this->embed->fields)->toArray(), 'name'));
+        $this->assertEquals('my value', Arr::get(Arr::first($this->embed->fields)->toArray(), 'value'));
+        $this->assertFalse(Arr::get(Arr::first($this->embed->fields)->toArray(), 'inline'));
+    }
+
+    /** @test */
+    public function it_can_embed_field_inline()
+    {
+        $this->embed->field('my name', 'my value', true);
+        $this->assertEquals('my name', Arr::get(Arr::first($this->embed->fields)->toArray(), 'name'));
+        $this->assertEquals('my value', Arr::get(Arr::first($this->embed->fields)->toArray(), 'value'));
+        $this->assertTrue(Arr::get(Arr::first($this->embed->fields)->toArray(), 'inline'));
+    }
+}

--- a/tests/DiscordWebhookMessageTest.php
+++ b/tests/DiscordWebhookMessageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Support\Arr;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class DiscordWebhookMessageTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \NotificationChannels\DiscordWebhook\DiscordWebhookMessage */
+    protected $message;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->message = new DiscordWebhookMessage();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_construct_with_a_new_message()
+    {
+        $message = new DiscordWebhookMessage('my construct message');
+        $this->assertEquals('my construct message', $message->content);
+    }
+
+    /** @test */
+    public function it_can_set_the_content()
+    {
+        $this->message->content('my message');
+        $this->assertEquals('my message', $this->message->content);
+    }
+
+    /** @test */
+    public function it_can_set_the_username()
+    {
+        $this->message->from('me');
+        $this->assertEquals('me', $this->message->username);
+    }
+
+    /** @test */
+    public function it_can_set_the_username_and_avatar()
+    {
+        $this->message->from('with avatar', 'avatar_url');
+        $this->assertEquals('with avatar', $this->message->username);
+        $this->assertEquals('avatar_url', $this->message->avatar_url);
+    }
+
+    /** @test */
+    public function it_can_enable_tts()
+    {
+        $this->message->tts();
+        $this->assertEquals('true', $this->message->tts);
+    }
+
+    /** @test */
+    public function it_can_disable_tts()
+    {
+        $this->message->tts();
+        $this->message->tts(false);
+        $this->assertEquals('false', $this->message->tts);
+    }
+
+    /** @test */
+    public function it_can_set_file()
+    {
+        $this->message->file('file content', 'file name');
+        $this->assertEquals('file content', Arr::get($this->message->toArray(), 'file.contents'));
+        $this->assertEquals('file name', Arr::get($this->message->toArray(), 'file.filename'));
+    }
+
+    /** @test */
+    public function it_can_embed_content()
+    {
+        $this->message->embed(function ($embed) {
+            $embed->description('embed description');
+        });
+        $this->assertEquals('embed description', Arr::get(Arr::first($this->message->embeds)->toArray(), 'description'));
+    }
+}

--- a/tests/TestEmptyNotification.php
+++ b/tests/TestEmptyNotification.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class TestEmptyNotification extends Notification
+{
+    public function toDiscordWebhook($notifiable)
+    {
+        return new DiscordWebhookMessage();
+    }
+}

--- a/tests/TestFileNotification.php
+++ b/tests/TestFileNotification.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class TestFileNotification extends Notification
+{
+    public function toDiscordWebhook($notifiable)
+    {
+        return (new DiscordWebhookMessage())->file('file content', 'file name');
+    }
+}

--- a/tests/TestNotifiable.php
+++ b/tests/TestNotifiable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+class TestNotifiable
+{
+    public function routeNotificationForDiscordWebhook()
+    {
+        return 'webhook_url';
+    }
+}

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class TestNotification extends Notification
+{
+    public function toDiscordWebhook($notifiable)
+    {
+        return (new DiscordWebhookMessage())
+            ->content('Test Message from Discord Webhook');
+    }
+}

--- a/tests/TestOtherNotifiable.php
+++ b/tests/TestOtherNotifiable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+class TestOtherNotifiable
+{
+    public function routeNotificationForOther()
+    {
+        return false;
+    }
+}

--- a/tests/TestUnsupportedNotification.php
+++ b/tests/TestUnsupportedNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\DiscordWebhook\Test;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\DiscordWebhook\DiscordWebhookMessage;
+
+class TestUnsupportedNotification extends Notification
+{
+    public function toDiscordWebhook($notifiable)
+    {
+        return (new DiscordWebhookMessage())->file('file content', 'file name')->embed(function ($embed) {
+            $embed->description('embed description');
+        });
+    }
+}


### PR DESCRIPTION
Alternative (low-effort way) to [laravel-notification-channels/discord](https://github.com/laravel-notification-channels/discord).
This Channel uses instead of a Discord Bot-User the Discord Webhook.

The benefits for Discord Webhooks are
- supports Embedded Rich Content
- higher Rate-Limits
- no Bot-User or Authentication required
