### PR TITLE
Add LINE Channel for Messenger / Chat / Social

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: PHPUnit tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.1, 8.2, 8.3]
+
+    name: Tests on PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer update --prefer-source --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.phpunit.cache
+/build
+/vendor
+composer.phar
+composer.lock
+.DS_Store

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -60,7 +60,7 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1726217638481</updated>
-      <workItem from="1726217639647" duration="379000" />
+      <workItem from="1726217639647" duration="458000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="84bc13b8-67e3-48a5-ad33-c904c38e1fab" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings" synchronizationState="SYNCHRONIZE">
+    <pharConfigPath>$PROJECT_DIR$/composer.json</pharConfigPath>
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="PhpWorkspaceProjectConfiguration" interpreter_name="/opt/homebrew/Cellar/php/8.3.3_1/bin/php" />
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 2
+}]]></component>
+  <component name="ProjectId" id="2m0dt3K2lFEhfwzZCzTPCjuyc5n" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "line",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration default="true" type="ComposerRunConfigurationType" factoryName="Composer Script">
+      <option name="pathToComposerJson" value="$PROJECT_DIR$/composer.json" />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-410509235cf1-JavaScript-PS-242.20224.427" />
+        <option value="bundled-php-predefined-a98d8de5180a-d6acee4cb394-com.jetbrains.php.sharedIndexes-PS-242.20224.427" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="84bc13b8-67e3-48a5-ad33-c904c38e1fab" name="Changes" comment="" />
+      <created>1726217638481</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1726217638481</updated>
+      <workItem from="1726217639647" duration="379000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,18 @@
+checks:
+    php:
+        remove_extra_empty_lines: true
+        remove_php_closing_tag: true
+        remove_trailing_whitespace: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: true
+            order_alphabetically: true
+        fix_php_opening_tag: true
+        fix_linefeed: true
+        fix_line_ending: true
+        fix_identation_4spaces: true
+        fix_doc_comments: true
+
+tools:
+    external_code_coverage: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: laravel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to `:package_name` will be documented in this file
+
+## 1.0.0 - 201X-XX-XX
+
+- initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) :author_name <:author_email>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,102 @@
-# New Notification Channels
+# LINE Laravel Notifications Channel
 
-### Suggesting a new channel
-Have a suggestion or working on a new channel? Please create a new issue for that service.
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/line.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/line)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/laravel-notification-channels/line/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/line)
+[![StyleCI](https://styleci.io/repos/241828511/shield)](https://styleci.io/repos/241828511)
+[![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/line.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/line)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/line/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/line/?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/line.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/line)
 
-### I'm working on a new channel
-Please create an issue for it if it does not already exist, then PR you code for review.
+## Introduction
 
-## Workflow for new channels
+This package makes it easy to send notifications using [LINE](https://line.me/) with Laravel 5.6+. 
 
-1) Head over to the [skeleton repo](https://github.com/laravel-notification-channels/skeleton) download a ZIP copy. This is important, to ensure you start from a fresh commit history.
-2) Use find/replace to replace all of the placeholders with the correct values (package name, author name, email, etc).
-3) Implement to logic for the channel & add tests.
-4) Fork this repo, add it as a remote and push your new channel to a branch.
-5) Submit a new PR against this repo for review.
+## Contents
 
-Take a look at our [FAQ](http://laravel-notification-channels.com/) to see our small list of rules, to provide top-notch notification channels.
+- [LINE Laravel Notifications Channel](#line-laravel-notifications-channel)
+  - [Introduction](#introduction)
+  - [Contents](#contents)
+  - [Installation](#installation)
+    - [Setting up the LINE service](#setting-up-the-line-service)
+  - [Usage](#usage)
+    - [Available methods](#available-methods)
+  - [Security](#security)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
+  - [License](#license)
+
+## Installation
+
+You can install the package via composer:
+
+```shell script
+$ composer require laravel-notification-channels/line
+```
+
+### Setting up the LINE service
+
+In order to send message to LINE channels, you need to obtain [Messaging API overview](https://developers.line.biz/en/docs/messaging-api/overview/).
+
+Add your LINE Message API Token to your `config/services.php`:
+
+```php
+// config/services.php
+...
+'line_message_api' => [
+    'token' => env('LINE_MESSAGE_TOKEN', 'YOUR MESSAGE TOKEN HERE'),
+],
+...
+```
+
+## Usage
+
+You can use the channel in your `via()` method inside the notification:
+
+```php
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Line\LineMessage;
+use NotificationChannels\Line\LineWebhookChannel;
+
+class TaskCompleted extends Notification
+{
+    public function via($notifiable): array
+    {
+        return [
+            'line',
+        ];
+    }
+
+    public function toLine($notifiable): LineMessage
+    {
+        return LineMessage::create('Test message')
+            ->to('line_user_id')
+            ->from('message_api_token'); // optional if set in config
+    }
+}
+```
+
+### Available methods
+
+`from()`: Sets the sender's access token.
+
+`to()`: Specifies the line user id to send the notification to.
+
+`content()`: Sets a content of the notification message. Only support plain text for now.
+
+## Security
+
+If you discover any security related issues, please email s950329@hotmail.com instead of using the issue tracker.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Credits
+
+- [Leo Chien](https://github.com/s950329)
+- [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,49 @@
+{
+    "name": "laravel-notification-channels/line",
+    "description": "LINE Notifications Channel for Laravel",
+    "homepage": "https://github.com/laravel-notification-channels/line",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Leo Chien",
+            "email": "s950329@hotmail.com",
+            "homepage": "https://google.com",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "illuminate/notifications": "~10.0 || ~11.0",
+        "illuminate/support": "~10.0 || ~11.0"
+    },
+    "require-dev": {
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^10.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\Line\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\Line\\Test\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "test:coverage": "phpunit --coverage-text --coverage-clover=coverage.clover"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\Line\\LineServiceProvider"
+            ]
+        }
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+    <coverage>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name=":service_name Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NotificationChannels\Line\Exceptions;
+
+use GuzzleHttp\Exception\ClientException;
+
+class CouldNotSendNotification extends \Exception
+{
+    /**
+     * Thrown when there's a bad response from the LINE.
+     *
+     * @param  \GuzzleHttp\Exception\ClientException  $exception
+     * @return static
+     */
+    public static function lineRespondedWithAnError(ClientException $exception)
+    {
+        $message = $exception->getResponse()->getBody();
+        $code = $exception->getResponse()->getStatusCode();
+
+        return new static("LINE responded with an error `{$code} - {$message}`");
+    }
+
+    /**
+     * Thrown when we're unable to communicate with LINE.
+     *
+     * @param  \Exception  $exception
+     * @return static
+     */
+    public static function couldNotCommunicateWithLine(\Exception $exception): self
+    {
+        return new static("The communication with LINE failed. Reason: {$exception->getMessage()}");
+    }
+
+    /**
+     * Thrown when there's no bot token provided.
+     */
+    public static function lineMessageTokenNotProvided(string $message): self
+    {
+        return new self($message);
+    }
+}

--- a/src/Line.php
+++ b/src/Line.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NotificationChannels\Line;
+
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException;
+use NotificationChannels\Line\Exceptions\CouldNotSendNotification;
+
+final class Line
+{
+    /** @var \GuzzleHttp\Client */
+    private $http;
+
+    /** @var string */
+    private $url;
+
+    /** @var string */
+    private $token;
+
+    /** @var string|null */
+    private $defaultChannel;
+
+    /**
+     * @param  string  $url
+     * @param  string|null  $defaultChannel
+     * @return void
+     */
+    public function __construct(HttpClient $http, string $token = null)
+    {
+        $this->http = $http;
+        $this->token = $token;
+    }
+
+    /**
+     * Returns Line token.
+     */
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function setToken(string $token): self
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * Send text message.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'                  => '',
+     *   'text'                     => '',
+     *   'parse_mode'               => '',
+     *   'disable_web_page_preview' => '',
+     *   'disable_notification'     => '',
+     *   'reply_to_message_id'      => '',
+     *   'reply_markup'             => '',
+     * ];
+     * </code>
+     *
+     * @see https://core.telegram.org/bots/api#sendmessage
+     *
+     * @throws CouldNotSendNotification
+     */
+    public function sendMessage(string $to, array $params): ?ResponseInterface
+    {
+        return $this->sendRequest($to, $params);
+    }
+
+    /**
+     * Perform a simple post request.
+     */
+    private function post(string $url, array $options): void
+    {
+        $this->http->post($url, $options);
+    }
+
+    /**
+     * Send an API request and return response.
+     *
+     *
+     * @throws CouldNotSendNotification
+     */
+    protected function sendRequest(string $to, array $params): ?ResponseInterface
+    {
+        if (blank($this->token)) {
+            throw CouldNotSendNotification::lineMessageTokenNotProvided('You must provide your line message token to make any API requests.');
+        }
+
+        $url = 'https://api.line.me/v2/bot/message/push';
+
+        try {
+            return $this->post($url, [
+                'json' => array_merge($params, [
+                    'to' => $to,
+                ]),
+                'headers' => [
+                    'Authorization' => 'Bearer '.$this->token,
+                ],
+            ]);
+        } catch (ClientException $exception) {
+            throw CouldNotSendNotification::lineRespondedWithAnError($exception);
+        } catch (\Exception $exception) {
+            throw CouldNotSendNotification::couldNotCommunicateWithLine($exception);
+        }
+    }
+}

--- a/src/LineChannel.php
+++ b/src/LineChannel.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NotificationChannels\Line;
+
+use GuzzleHttp\Psr7\Response;
+use NotificationChannels\Line\Exceptions\CouldNotSendNotification;
+use Illuminate\Notifications\Notification;
+use GuzzleHttp\Exception\ClientException;
+use Exception;
+
+class LineChannel
+{
+    /** @var \NotificationChannels\Line\Line The HTTP client instance. */
+    private $line;
+
+    public function __construct(Line $line)
+    {
+        $this->line = $line;
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     *
+     * @throws \NotificationChannels\:channel_namespace\Exceptions\CouldNotSendNotification
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        /** @var \NotificationChannels\Line\LineMessage $message */
+        $message = $notification->toLine($notifiable);
+
+        $to = $message->getTo() ?: $notifiable->routeNotificationFor('line');
+        if ($to === null) {
+            return null;
+        }
+
+        if ($message->getFrom()) {
+            $this->line->setToken($message->getFrom());
+        }
+
+        try {
+            $response = $this->sendMessage($to, $message);
+        } catch (ClientException $exception) {
+            throw CouldNotSendNotification::lineRespondedWithAnError($exception);
+        } catch (Exception $exception) {
+            throw CouldNotSendNotification::couldNotCommunicateWithLine($exception);
+        }
+
+        return $response instanceof Response ? json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR) : $response;
+    }
+
+    /**
+     * @param  string  $to
+     * @param  \NotificationChannels\LINE\LINEMessage  $message
+     * @return void
+     */
+    private function sendMessage(string $to, LineMessage $message): void
+    {
+        $this->line->sendMessage($to, $message->toArray());
+    }
+}

--- a/src/LineChannel.php
+++ b/src/LineChannel.php
@@ -2,11 +2,11 @@
 
 namespace NotificationChannels\Line;
 
-use GuzzleHttp\Psr7\Response;
-use NotificationChannels\Line\Exceptions\CouldNotSendNotification;
-use Illuminate\Notifications\Notification;
-use GuzzleHttp\Exception\ClientException;
 use Exception;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Line\Exceptions\CouldNotSendNotification;
 
 class LineChannel
 {
@@ -21,10 +21,10 @@ class LineChannel
     /**
      * Send the given notification.
      *
-     * @param mixed $notifiable
-     * @param \Illuminate\Notifications\Notification $notification
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification $notification
      *
-     * @throws \NotificationChannels\:channel_namespace\Exceptions\CouldNotSendNotification
+     * @throws \NotificationChannels\Line\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
     {

--- a/src/LineChannel.php
+++ b/src/LineChannel.php
@@ -22,7 +22,7 @@ class LineChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification $notification
+     * @param  \Illuminate\Notifications\Notification  $notification
      *
      * @throws \NotificationChannels\Line\Exceptions\CouldNotSendNotification
      */

--- a/src/LineMessage.php
+++ b/src/LineMessage.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace NotificationChannels\Line;
+
+class LineMessage
+{
+    /** @var string|null Line user id. */
+    protected $to = null;
+
+    /** @var string|null A user or app access token. */
+    protected $from = null;
+
+    /** @var string The text content of the message. */
+    protected $content;
+
+    /**
+     * Create a new instance of LineMessage.
+     *
+     * @return static
+     */
+    public static function create(string $content = ''): self
+    {
+        return new static($content);
+    }
+
+    /**
+     * Create a new instance of LineMessage.
+     */
+    public function __construct(string $content = '')
+    {
+        $this->content($content);
+    }
+
+    public function getTo(): ?string
+    {
+        return $this->to;
+    }
+
+    public function to(string $to): self
+    {
+        $this->to = $to;
+
+        return $this;
+    }
+
+    public function getFrom(): ?string
+    {
+        return $this->from;
+    }
+
+    /**
+     * Set the sender's access token.
+     *
+     * @return $this
+     */
+    public function from(string $accessToken): self
+    {
+        $this->from = $accessToken;
+
+        return $this;
+    }
+
+    /**
+     * Set the content of the Line message.
+     * Supports GitHub flavoured markdown.
+     *
+     * @return $this
+     */
+    public function content(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the LineMessage.
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'messages' => [
+                [
+                    'type' => 'text',
+                    'text' => $this->content,
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/LineServiceProvider.php
+++ b/src/LineServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace NotificationChannels\Line;
+
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Notifications\ChannelManager;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\ServiceProvider;
+
+class LineServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the application services.
+     */
+    public function register(): void
+    {
+        $this->app->bind(Line::class, static fn () => new Line(
+            app(HttpClient::class),
+            config('services.line_message_api.token'),
+        ));
+
+        Notification::resolved(static function (ChannelManager $service) {
+            $service->extend('line', static fn ($app) => $app->make(LineChannel::class));
+        });
+    }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NotificationChannels\:channel_namespace\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    /** @test */
+    public function true_is_true()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NotificationChannels\:channel_namespace\Test;
+namespace NotificationChannels\Line\Test;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
A notification channel based on the LINE Message API, supporting the sending of plain text messages.
Reference: https://developers.line.biz/en/docs/messaging-api/overview/