### PR TITLE
Add kwtSMS notification channel for Kuwait SMS gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/vendor/
+composer.lock
+.phpunit.result.cache
+.phpunit.cache/
+.claude/
+CLAUDE.md
+docs/
+.env
+.env.*
+napkin.md
+*.log
+.idea/
+.vscode/
+PRD.md
+PLAN.md

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: laravel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.0.0 - 2026-03-17
+
+### Added
+
+- KwtSmsChannel for sending SMS via kwtSMS gateway
+- KwtSmsMessage fluent builder with content and sender methods
+- KwtSmsServiceProvider with config publishing
+- CouldNotSendNotification exception for API errors
+- Full test suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Contributions are welcome and will be fully credited.
+
+We accept contributions via Pull Requests on [GitHub](https://github.com/boxlinknet/kwtsms-notification-channel).
+
+## Pull Requests
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)**: Check the code style with `composer lint`.
+- **Add tests**: Your patch won't be accepted if it doesn't have tests.
+- **Document any change in behaviour**: Make sure the `README.md` is kept up to date.
+- **One pull request per feature**: If you want to do more than one thing, send multiple pull requests.
+- **Send coherent history**: Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+
+## Running Tests
+
+```bash
+composer test
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) M Alhassoun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) M Alhassoun
+Copyright (c) BoxLink
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/kwtsms/kwtsms-notification-channel.svg?style=flat-square)](https://packagist.org/packages/kwtsms/kwtsms-notification-channel)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 
-This package makes it easy to send notifications using [kwtSMS](https://kwtsms.com) with Laravel.
+This package makes it easy to send notifications using [kwtSMS](https://www.kwtsms.com) with Laravel.
 
 ## Contents
 
@@ -46,7 +46,7 @@ KWTSMS_TEST_MODE=false
 
 To get started, you need a kwtSMS account:
 
-1. Sign up at [kwtsms.com](https://kwtsms.com)
+1. Sign up at [kwtsms.com](https://www.kwtsms.com)
 2. Obtain your API username and password from the dashboard
 3. Register a Sender ID (or use the default `KWT-SMS`)
 4. Add the credentials to your `.env` file as shown above
@@ -124,7 +124,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Credits
 
-- [M Alhassoun](https://github.com/boxlinknet)
+- [BoxLink](https://github.com/boxlinknet)
 - [All Contributors](../../contributors)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,17 +1,132 @@
-# New Notification Channels
+# kwtSMS Notification Channel for Laravel
 
-### Suggesting a new channel
-Have a suggestion or working on a new channel? Please create a new issue for that service.
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/kwtsms/kwtsms-notification-channel.svg?style=flat-square)](https://packagist.org/packages/kwtsms/kwtsms-notification-channel)
+[![Total Downloads](https://img.shields.io/packagist/dt/kwtsms/kwtsms-notification-channel.svg?style=flat-square)](https://packagist.org/packages/kwtsms/kwtsms-notification-channel)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 
-### I'm working on a new channel
-Please create an issue for it if it does not already exist, then PR you code for review.
+This package makes it easy to send notifications using [kwtSMS](https://kwtsms.com) with Laravel.
 
-## Workflow for new channels
+## Contents
 
-1) Head over to the [skeleton repo](https://github.com/laravel-notification-channels/skeleton) download a ZIP copy. This is important, to ensure you start from a fresh commit history.
-2) Use find/replace to replace all of the placeholders with the correct values (package name, author name, email, etc).
-3) Implement to logic for the channel & add tests.
-4) Fork this repo, add it as a remote and push your new channel to a branch.
-5) Submit a new PR against this repo for review.
+- [Installation](#installation)
+- [Setting up kwtSMS](#setting-up-kwtsms)
+- [Usage](#usage)
+- [Available Methods](#available-methods)
+- [Changelog](#changelog)
+- [Testing](#testing)
+- [Security](#security)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [License](#license)
 
-Take a look at our [FAQ](http://laravel-notification-channels.com/) to see our small list of rules, to provide top-notch notification channels.
+## Installation
+
+You can install the package via Composer:
+
+```bash
+composer require kwtsms/kwtsms-notification-channel
+```
+
+Publish the configuration file:
+
+```bash
+php artisan vendor:publish --provider="NotificationChannels\KwtSms\KwtSmsServiceProvider" --tag="config"
+```
+
+Add your kwtSMS credentials to your `.env` file:
+
+```dotenv
+KWTSMS_USERNAME=your-username
+KWTSMS_PASSWORD=your-password
+KWTSMS_SENDER=your-sender-id
+KWTSMS_TEST_MODE=false
+```
+
+## Setting up kwtSMS
+
+To get started, you need a kwtSMS account:
+
+1. Sign up at [kwtsms.com](https://kwtsms.com)
+2. Obtain your API username and password from the dashboard
+3. Register a Sender ID (or use the default `KWT-SMS`)
+4. Add the credentials to your `.env` file as shown above
+
+## Usage
+
+Create a notification class that uses the `KwtSmsChannel`:
+
+```php
+use Illuminate\Notifications\Notification;
+use NotificationChannels\KwtSms\KwtSmsChannel;
+use NotificationChannels\KwtSms\KwtSmsMessage;
+
+class OrderShipped extends Notification
+{
+    public function via($notifiable): array
+    {
+        return [KwtSmsChannel::class];
+    }
+
+    public function toKwtSms($notifiable): KwtSmsMessage
+    {
+        return KwtSmsMessage::create("Your order #{$this->order->id} has been shipped!");
+    }
+}
+```
+
+Add the `routeNotificationForKwtSms` method to your notifiable model:
+
+```php
+public function routeNotificationForKwtSms($notification): string
+{
+    return $this->phone; // International format: 96598765432
+}
+```
+
+You can also return a plain string from `toKwtSms` instead of a `KwtSmsMessage` object:
+
+```php
+public function toKwtSms($notifiable): string
+{
+    return 'Your order has been shipped!';
+}
+```
+
+## Available Methods
+
+### KwtSmsMessage
+
+| Method | Description |
+|---|---|
+| `create(string $content = '')` | Static factory to create a new message |
+| `content(string $content)` | Set the message content |
+| `sender(string $sender)` | Override the default sender ID |
+| `getContent()` | Get the message content |
+| `getSender()` | Get the sender ID (null if not set) |
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
+## Testing
+
+```bash
+composer test
+```
+
+## Security
+
+If you discover any security related issues, please use the issue tracker on GitHub instead of sending an email.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Credits
+
+- [M Alhassoun](https://github.com/boxlinknet)
+- [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [LICENSE](LICENSE) for more information.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,53 @@
+{
+    "name": "kwtsms/kwtsms-notification-channel",
+    "description": "kwtSMS notification channel for Laravel",
+    "homepage": "https://github.com/boxlinknet/kwtsms-notification-channel",
+    "license": "MIT",
+    "keywords": [
+        "kwtsms",
+        "sms",
+        "laravel",
+        "notification",
+        "kuwait"
+    ],
+    "authors": [
+        {
+            "name": "M Alhassoun",
+            "homepage": "https://kwtsms.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "illuminate/notifications": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "kwtsms/kwtsms": "^1.3"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^10.0|^11.0",
+        "laravel/pint": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\KwtSms\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\KwtSms\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\KwtSms\\KwtSmsServiceProvider"
+            ]
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "lint": "vendor/bin/pint"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "authors": [
         {
-            "name": "M Alhassoun",
-            "homepage": "https://kwtsms.com"
+            "name": "BoxLink",
+            "homepage": "https://www.kwtsms.com"
         }
     ],
     "require": {

--- a/config/kwtsms.php
+++ b/config/kwtsms.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'username'  => env('KWTSMS_USERNAME', ''),
-    'password'  => env('KWTSMS_PASSWORD', ''),
-    'sender'    => env('KWTSMS_SENDER', 'KWT-SMS'),
+    'username' => env('KWTSMS_USERNAME', ''),
+    'password' => env('KWTSMS_PASSWORD', ''),
+    'sender' => env('KWTSMS_SENDER', 'KWT-SMS'),
     'test_mode' => env('KWTSMS_TEST_MODE', false),
 ];

--- a/config/kwtsms.php
+++ b/config/kwtsms.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'username' => env('KWTSMS_USERNAME', ''),
+    'password' => env('KWTSMS_PASSWORD', ''),
+    'sender' => env('KWTSMS_SENDER', 'KWT-SMS'),
+    'test_mode' => env('KWTSMS_TEST_MODE', false),
+];

--- a/config/kwtsms.php
+++ b/config/kwtsms.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'username' => env('KWTSMS_USERNAME', ''),
-    'password' => env('KWTSMS_PASSWORD', ''),
-    'sender' => env('KWTSMS_SENDER', 'KWT-SMS'),
+    'username'  => env('KWTSMS_USERNAME', ''),
+    'password'  => env('KWTSMS_PASSWORD', ''),
+    'sender'    => env('KWTSMS_SENDER', 'KWT-SMS'),
     'test_mode' => env('KWTSMS_TEST_MODE', false),
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    backupGlobals="false"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\KwtSms\Exceptions;
+
+class CouldNotSendNotification extends \Exception
+{
+    public static function serviceRespondedWithError(string $code, string $description): static
+    {
+        return new static("kwtSMS API error [{$code}]: {$description}");
+    }
+}

--- a/src/KwtSmsChannel.php
+++ b/src/KwtSmsChannel.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NotificationChannels\KwtSms;
+
+use Illuminate\Notifications\Notification;
+use KwtSMS\KwtSMS;
+use NotificationChannels\KwtSms\Exceptions\CouldNotSendNotification;
+
+class KwtSmsChannel
+{
+    public function __construct(protected KwtSMS $client) {}
+
+    public function send(mixed $notifiable, Notification $notification): ?array
+    {
+        $message = $notification->toKwtSms($notifiable);
+
+        if (is_string($message)) {
+            $message = KwtSmsMessage::create($message);
+        }
+
+        if (empty($message->getContent())) {
+            return null;
+        }
+
+        $to = $notifiable->routeNotificationFor('KwtSms', $notification);
+
+        if (empty($to)) {
+            return null;
+        }
+
+        $sender = $message->getSender() ?? config('kwtsms.sender', 'KWT-SMS');
+
+        $response = $this->client->send($to, $message->getContent(), $sender);
+
+        if (isset($response['result']) && $response['result'] === 'ERROR') {
+            throw CouldNotSendNotification::serviceRespondedWithError(
+                $response['code'] ?? 'UNKNOWN',
+                $response['description'] ?? 'Unknown error'
+            );
+        }
+
+        return $response;
+    }
+}

--- a/src/KwtSmsChannel.php
+++ b/src/KwtSmsChannel.php
@@ -8,7 +8,9 @@ use NotificationChannels\KwtSms\Exceptions\CouldNotSendNotification;
 
 class KwtSmsChannel
 {
-    public function __construct(protected KwtSMS $client) {}
+    public function __construct(protected KwtSMS $client)
+    {
+    }
 
     public function send(mixed $notifiable, Notification $notification): ?array
     {

--- a/src/KwtSmsMessage.php
+++ b/src/KwtSmsMessage.php
@@ -10,7 +10,7 @@ class KwtSmsMessage
 
     public static function create(string $content = ''): static
     {
-        return (new static)->content($content);
+        return (new static())->content($content);
     }
 
     public function content(string $content): static

--- a/src/KwtSmsMessage.php
+++ b/src/KwtSmsMessage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NotificationChannels\KwtSms;
+
+class KwtSmsMessage
+{
+    protected string $content = '';
+
+    protected ?string $sender = null;
+
+    public static function create(string $content = ''): static
+    {
+        return (new static)->content($content);
+    }
+
+    public function content(string $content): static
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function sender(string $sender): static
+    {
+        $this->sender = $sender;
+
+        return $this;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getSender(): ?string
+    {
+        return $this->sender;
+    }
+}

--- a/src/KwtSmsServiceProvider.php
+++ b/src/KwtSmsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace NotificationChannels\KwtSms;
+
+use Illuminate\Support\ServiceProvider;
+use KwtSMS\KwtSMS;
+
+class KwtSmsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/kwtsms.php', 'kwtsms');
+
+        $this->app->singleton(KwtSMS::class, function () {
+            return new KwtSMS(
+                username: config('kwtsms.username', ''),
+                password: config('kwtsms.password', ''),
+                sender_id: config('kwtsms.sender', 'KWT-SMS'),
+                test_mode: (bool) config('kwtsms.test_mode', false),
+            );
+        });
+
+        $this->app->singleton(KwtSmsChannel::class, function ($app) {
+            return new KwtSmsChannel($app->make(KwtSMS::class));
+        });
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/kwtsms.php' => config_path('kwtsms.php'),
+            ], 'config');
+        }
+    }
+}

--- a/tests/KwtSmsChannelTest.php
+++ b/tests/KwtSmsChannelTest.php
@@ -36,7 +36,7 @@ class KwtSmsChannelTest extends TestCase
             ->with('96598765432', 'Test message', 'KWT-SMS')
             ->andReturn(['result' => 'OK', 'msg-id' => '12345']);
 
-        $response = $this->channel->send(new TestNotifiable, new TestNotification);
+        $response = $this->channel->send(new TestNotifiable(), new TestNotification());
 
         $this->assertSame('OK', $response['result']);
     }
@@ -45,7 +45,7 @@ class KwtSmsChannelTest extends TestCase
     {
         $this->client->shouldNotReceive('send');
 
-        $response = $this->channel->send(new TestNotifiable, new TestEmptyNotification);
+        $response = $this->channel->send(new TestNotifiable(), new TestEmptyNotification());
 
         $this->assertNull($response);
     }
@@ -54,7 +54,7 @@ class KwtSmsChannelTest extends TestCase
     {
         $this->client->shouldNotReceive('send');
 
-        $response = $this->channel->send(new TestNotifiableWithoutPhone, new TestNotification);
+        $response = $this->channel->send(new TestNotifiableWithoutPhone(), new TestNotification);
 
         $this->assertNull($response);
     }
@@ -69,7 +69,7 @@ class KwtSmsChannelTest extends TestCase
         $this->expectException(CouldNotSendNotification::class);
         $this->expectExceptionMessage('kwtSMS API error [ERR001]: Invalid credentials');
 
-        $this->channel->send(new TestNotifiable, new TestNotification);
+        $this->channel->send(new TestNotifiable(), new TestNotification());
     }
 
     public function test_it_accepts_string_message(): void
@@ -80,7 +80,7 @@ class KwtSmsChannelTest extends TestCase
             ->with('96598765432', 'String message', 'KWT-SMS')
             ->andReturn(['result' => 'OK']);
 
-        $response = $this->channel->send(new TestNotifiable, new TestStringNotification);
+        $response = $this->channel->send(new TestNotifiable(), new TestStringNotification());
 
         $this->assertSame('OK', $response['result']);
     }

--- a/tests/KwtSmsChannelTest.php
+++ b/tests/KwtSmsChannelTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace NotificationChannels\KwtSms\Tests;
+
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use KwtSMS\KwtSMS;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use NotificationChannels\KwtSms\Exceptions\CouldNotSendNotification;
+use NotificationChannels\KwtSms\KwtSmsChannel;
+use NotificationChannels\KwtSms\KwtSmsMessage;
+use Orchestra\Testbench\TestCase;
+
+class KwtSmsChannelTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected KwtSMS|Mockery\MockInterface $client;
+
+    protected KwtSmsChannel $channel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = Mockery::mock(KwtSMS::class);
+        $this->channel = new KwtSmsChannel($this->client);
+    }
+
+    public function test_it_can_send_notification(): void
+    {
+        $this->client
+            ->shouldReceive('send')
+            ->once()
+            ->with('96598765432', 'Test message', 'KWT-SMS')
+            ->andReturn(['result' => 'OK', 'msg-id' => '12345']);
+
+        $response = $this->channel->send(new TestNotifiable, new TestNotification);
+
+        $this->assertSame('OK', $response['result']);
+    }
+
+    public function test_it_does_not_send_when_content_is_empty(): void
+    {
+        $this->client->shouldNotReceive('send');
+
+        $response = $this->channel->send(new TestNotifiable, new TestEmptyNotification);
+
+        $this->assertNull($response);
+    }
+
+    public function test_it_does_not_send_when_no_phone_number(): void
+    {
+        $this->client->shouldNotReceive('send');
+
+        $response = $this->channel->send(new TestNotifiableWithoutPhone, new TestNotification);
+
+        $this->assertNull($response);
+    }
+
+    public function test_it_throws_on_api_error(): void
+    {
+        $this->client
+            ->shouldReceive('send')
+            ->once()
+            ->andReturn(['result' => 'ERROR', 'code' => 'ERR001', 'description' => 'Invalid credentials']);
+
+        $this->expectException(CouldNotSendNotification::class);
+        $this->expectExceptionMessage('kwtSMS API error [ERR001]: Invalid credentials');
+
+        $this->channel->send(new TestNotifiable, new TestNotification);
+    }
+
+    public function test_it_accepts_string_message(): void
+    {
+        $this->client
+            ->shouldReceive('send')
+            ->once()
+            ->with('96598765432', 'String message', 'KWT-SMS')
+            ->andReturn(['result' => 'OK']);
+
+        $response = $this->channel->send(new TestNotifiable, new TestStringNotification);
+
+        $this->assertSame('OK', $response['result']);
+    }
+}
+
+class TestNotifiable
+{
+    use Notifiable;
+
+    public function routeNotificationForKwtSms(): string
+    {
+        return '96598765432';
+    }
+}
+
+class TestNotifiableWithoutPhone
+{
+    use Notifiable;
+
+    public function routeNotificationForKwtSms(): string
+    {
+        return '';
+    }
+}
+
+class TestNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return [KwtSmsChannel::class];
+    }
+
+    public function toKwtSms($notifiable): KwtSmsMessage
+    {
+        return KwtSmsMessage::create('Test message');
+    }
+}
+
+class TestEmptyNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return [KwtSmsChannel::class];
+    }
+
+    public function toKwtSms($notifiable): KwtSmsMessage
+    {
+        return KwtSmsMessage::create('');
+    }
+}
+
+class TestStringNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return [KwtSmsChannel::class];
+    }
+
+    public function toKwtSms($notifiable): string
+    {
+        return 'String message';
+    }
+}

--- a/tests/KwtSmsMessageTest.php
+++ b/tests/KwtSmsMessageTest.php
@@ -9,7 +9,7 @@ class KwtSmsMessageTest extends TestCase
 {
     public function test_can_create_message_with_content(): void
     {
-        $message = new KwtSmsMessage;
+        $message = new KwtSmsMessage();
         $message->content('Hello');
 
         $this->assertSame('Hello', $message->getContent());
@@ -31,14 +31,14 @@ class KwtSmsMessageTest extends TestCase
 
     public function test_content_defaults_to_empty_string(): void
     {
-        $message = new KwtSmsMessage;
+        $message = new KwtSmsMessage();
 
         $this->assertSame('', $message->getContent());
     }
 
     public function test_sender_defaults_to_null(): void
     {
-        $message = new KwtSmsMessage;
+        $message = new KwtSmsMessage();
 
         $this->assertNull($message->getSender());
     }

--- a/tests/KwtSmsMessageTest.php
+++ b/tests/KwtSmsMessageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NotificationChannels\KwtSms\Tests;
+
+use NotificationChannels\KwtSms\KwtSmsMessage;
+use PHPUnit\Framework\TestCase;
+
+class KwtSmsMessageTest extends TestCase
+{
+    public function test_can_create_message_with_content(): void
+    {
+        $message = new KwtSmsMessage;
+        $message->content('Hello');
+
+        $this->assertSame('Hello', $message->getContent());
+    }
+
+    public function test_can_create_message_via_static_create(): void
+    {
+        $message = KwtSmsMessage::create('Hello');
+
+        $this->assertSame('Hello', $message->getContent());
+    }
+
+    public function test_can_set_sender(): void
+    {
+        $message = KwtSmsMessage::create('Hello')->sender('MySender');
+
+        $this->assertSame('MySender', $message->getSender());
+    }
+
+    public function test_content_defaults_to_empty_string(): void
+    {
+        $message = new KwtSmsMessage;
+
+        $this->assertSame('', $message->getContent());
+    }
+
+    public function test_sender_defaults_to_null(): void
+    {
+        $message = new KwtSmsMessage;
+
+        $this->assertNull($message->getSender());
+    }
+}


### PR DESCRIPTION
## Summary

  - Adds a notification channel for kwtSMS (https://www.kwtsms.com), the primary SMS gateway in Kuwait
  - Regional SMS provider with public API and open signup, similar to accepted channels like TurboSMS (Ukraine), NetGSM (Turkey), and SmsPoh (Myanmar)
  - Built from the skeleton repo, includes full test suite

  ## Package Details

  - **Package repo:** https://github.com/boxlinknet/kwtsms-notification-channel
  - **Packagist:** https://packagist.org/packages/kwtsms/kwtsms-notification-channel
  - **Base SDK:** https://packagist.org/packages/kwtsms/kwtsms
  - **Supports:** PHP 8.1+, Laravel 10/11/12

  ## What's Included

  - KwtSmsChannel for sending SMS via kwtSMS API
  - KwtSmsMessage fluent builder with content and sender methods
  - KwtSmsServiceProvider with config publishing
  - CouldNotSendNotification exception for API errors
  - Full test suite (10 tests, 16 assertions)
  - PSR-2 compliant (Laravel Pint)

  Resolves #172

  I'm committed to long-term maintenance and happy to help review other channel submissions as well (ref #156).